### PR TITLE
Resolved Mobile Text Overflow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -237,6 +237,7 @@ code {
   background: var(--main-bg-dark);
   padding: 0.2rem;
   border-radius: 5px;
+  word-break: break-word;
 }
 
 pre {


### PR DESCRIPTION
Simple fix was to include `word-break: break-word` in App.vue styling
>> Committing this before attempting Command reformating